### PR TITLE
Fail the check if can't check migrations

### DIFF
--- a/lib/ok_computer/built_in_checks/active_record_migrations_check.rb
+++ b/lib/ok_computer/built_in_checks/active_record_migrations_check.rb
@@ -1,0 +1,24 @@
+module OkComputer
+  class ActiveRecordMigrationsCheck < Check
+
+    # Public: Check if migrations are pending or not
+    def check
+      return unsupported unless ActiveRecord::Migrator.respond_to?(:needs_migration?)
+
+      if ActiveRecord::Migrator.needs_migration?
+        mark_failure
+        mark_message "Pending migrations"
+      else
+        mark_message "NO pending migrations"
+      end
+    end
+
+    private
+
+    # Private: Fail the check if ActiveRecord cannot check migration status
+    def unsupported
+      mark_failure
+      mark_message "This version of ActiveRecord does not support checking whether migrations are pending"
+    end
+  end
+end

--- a/lib/okcomputer.rb
+++ b/lib/okcomputer.rb
@@ -12,6 +12,7 @@ require "ok_computer/built_in_checks/ping_check"
 
 require "ok_computer/built_in_checks/action_mailer_check"
 require "ok_computer/built_in_checks/active_record_check"
+require "ok_computer/built_in_checks/active_record_migrations_check"
 require "ok_computer/built_in_checks/app_version_check"
 require "ok_computer/built_in_checks/cache_check"
 require "ok_computer/built_in_checks/default_check"

--- a/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
+++ b/spec/ok_computer/built_in_checks/active_record_migrations_check_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+module OkComputer
+  describe ActiveRecordMigrationsCheck do
+    it "is a subclass of Check" do
+      subject.should be_a Check
+    end
+
+    context "#check" do
+      context "if activerecord supports needs_migration?" do
+        before do
+          allow(ActiveRecord::Migrator).to receive(:respond_to?).with(:needs_migration?).and_return(true)
+        end
+
+        context "with no pending migrations" do
+          before do
+            expect(ActiveRecord::Migrator).to receive(:needs_migration?).and_return(false)
+          end
+
+          it { should be_successful }
+          it { should have_message "NO pending migrations" }
+        end
+
+        context "with pending migrations" do
+          before do
+            expect(ActiveRecord::Migrator).to receive(:needs_migration?).and_return(true)
+          end
+
+          it { should_not be_successful }
+          it { should have_message "Pending migrations" }
+        end
+      end
+
+      context "on older versions of ActiveRecord" do
+        before do
+          allow(ActiveRecord::Migrator).to receive(:respond_to?).with(:needs_migration?).and_return(false)
+        end
+
+        it { should_not be_successful }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a proposed tweak to https://github.com/sportngin/okcomputer/pull/126.

Failing the check feels safer than preventing the app from booting when initializing this check with an older version of Rails.